### PR TITLE
YAML and JSON-based detection for games and RCS.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 urwrstkn8mare
+Copyright (c) 2020 Samit Shaikh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.22.0
+pyyaml==5.3.1
 galaxy.plugin.api==0.65.1
 galaxyutils==0.1.5

--- a/src/consts.py
+++ b/src/consts.py
@@ -9,10 +9,11 @@ class GameID:
 
 
 GAME_IDS = [GameID.legends_of_runeterra, GameID.league_of_legends, GameID.valorant]
+# Registry info is still needed to detect Vanguard.
 REGISTRY_START_PATHS = [winreg.HKEY_CURRENT_USER, winreg.HKEY_LOCAL_MACHINE]
 SOFTWARE_PATHS = ["SOFTWARE\\", "SOFTWARE\\WOW6432Node\\"]
 UNINSTALL_REGISTRY_PATH = "Microsoft\\Windows\\CurrentVersion\\Uninstall\\"
-GAME_REGISTY_PATH = {
+GAME_REGISTRY_PATH = {
     GameID.league_of_legends: "Riot Game league_of_legends.live",
     GameID.legends_of_runeterra: "Riot Game bacon.live",
     GameID.valorant: "Riot Game valorant.live",

--- a/src/local.py
+++ b/src/local.py
@@ -20,7 +20,9 @@ class LocalClient:
         self.process = dict.fromkeys(GAME_IDS, None)
         self.install_location = dict.fromkeys(
             list(GAME_REGISTRY_PATH.keys()), None)
-        self.riot_client_services_path = None
+        self.riot_client_services_path = self.get_rcs_path()
+        if not os.path.isfile(self.riot_client_services_path):
+            self.riot_client_services_path = None
         self._vanguard_uninstall_path = None
 
     def game_running(self, game_id) -> bool:
@@ -51,16 +53,8 @@ class LocalClient:
         )
 
     def update_installed(self):
-        # Try to locate Riot Client Services using the settings json file.
-        try:
-            with open(utils.misc.get_riot_client_installs_path(), 'r') as file:
-                client_installs = json.load(file)
-                self.riot_client_services_path = os.path.abspath(client_installs['rc_default'])
-        except:
-            pass
-
-        if self.riot_client_services_path is not None and not os.path.isfile(self.riot_client_services_path):
-            self.riot_client_services_path = None
+        if self.riot_client_services_path == None:
+            self.riot_client_services_path = self.get_rcs_path()
         self._vanguard_uninstall_path = None
 
         for game_id in GAME_IDS:
@@ -86,3 +80,13 @@ class LocalClient:
                             install_path)
                 except:
                     self.install_location[game_id] = None
+
+    def get_rcs_path(self):
+        try:
+            with open(utils.misc.get_riot_client_installs_path(), 'r') as file:
+                client_installs = json.load(file)
+                rcs_path = os.path.abspath(client_installs['rc_default'])
+        except:
+            rcs_path = None
+            pass
+        return rcs_path

--- a/src/local.py
+++ b/src/local.py
@@ -2,7 +2,7 @@ import json, os, winreg
 
 from yaml import load, FullLoader
 
-import utils
+import utils.misc
 from consts import (
     GameID,
     GAME_IDS,
@@ -36,7 +36,7 @@ class LocalClient:
         return self.install_location[game_id] is not None
 
     def launch(self, game_id, *, save_process=True):
-        p = utils.open_path(
+        p = utils.misc.open_path(
             self.riot_client_services_path,
             [f"--launch-product={game_id}", "--launch-patchline=live"],
         )
@@ -45,15 +45,15 @@ class LocalClient:
         return p
 
     def uninstall(self, game_id):
-        utils.open_path(
+        utils.misc.open_path(
             self.riot_client_services_path,
             [f"--uninstall-product={game_id}", "--uninstall-patchline=live"],
         )
 
     def update_installed(self):
-        # Try to locate Riot Client Services using the settings yaml file.
+        # Try to locate Riot Client Services using the settings json file.
         try:
-            with open(utils.get_riot_client_installs_path(), 'r') as file:
+            with open(utils.misc.get_riot_client_installs_path(), 'r') as file:
                 client_installs = json.load(file)
                 self.riot_client_services_path = os.path.abspath(client_installs['rc_default'])
         except:
@@ -79,7 +79,7 @@ class LocalClient:
             # Read product_install_full_path from yaml.
             else:
                 try:
-                    with open(utils.get_product_settings_path(game_id), 'r') as file:
+                    with open(utils.misc.get_product_settings_path(game_id), 'r') as file:
                         product_settings = load(file, Loader=FullLoader)
                         install_path = product_settings['product_install_full_path']
                         self.install_location[game_id] = os.path.abspath(

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -85,6 +85,7 @@ class RiotPlugin(Plugin):
             utils.misc.open_path(self.local_client._vanguard_uninstall_path)
 
     async def launch_game(self, game_id):
+        log.debug("RCS location: "+ self.local_client.riot_client_services_path)
         self.local_client.update_installed()
         self.local_client.launch(game_id)
 

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -14,7 +14,7 @@ from galaxyutils import time_tracker
 
 from consts import GameID, DOWNLOAD_URL, GAME_IDS, LOCAL_FILE_CACHE
 from local import LocalClient
-import utils
+import utils.misc
 from version import __version__
 
 log = logging.getLogger(__name__)
@@ -63,11 +63,11 @@ class RiotPlugin(Plugin):
     async def prepare_local_size_context(self, game_ids):
         sizes = []
         for game_id in GAME_IDS:
-            size = await utils.get_size_at_path(
+            size = await utils.misc.get_size_at_path(
                 self.local_client.install_location[game_id], if_none=0
             )
             if game_id == GameID.valorant:
-                size += await utils.get_size_at_path(
+                size += await utils.misc.get_size_at_path(
                     self.local_client.install_location[GameID.vanguard], if_none=0
                 )
             if size == 0:
@@ -82,7 +82,7 @@ class RiotPlugin(Plugin):
         self.local_client.update_installed()
         self.local_client.uninstall(game_id)
         if game_id == GameID.valorant and self.local_client._vanguard_uninstall_path is not None:
-            utils.open_path(self.local_client._vanguard_uninstall_path)
+            utils.misc.open_path(self.local_client._vanguard_uninstall_path)
 
     async def launch_game(self, game_id):
         self.local_client.update_installed()
@@ -101,7 +101,7 @@ class RiotPlugin(Plugin):
         log.info("Installing game")
         self.local_client.update_installed()
         if self.local_client.riot_client_services_path is None:
-            utils.open_path(utils.download(DOWNLOAD_URL[game_id]))
+            utils.misc.open_path(utils.misc.download(DOWNLOAD_URL[game_id]))
         else:
             self.local_client.launch(game_id, save_process=False)
 
@@ -145,7 +145,7 @@ class RiotPlugin(Plugin):
             return None
 
     def handshake_complete(self):
-        utils.cleanup()
+        utils.misc.cleanup()
         if "game_time_cache" in self.persistent_cache:
             self.game_time_cache = pickle.loads(
                 bytes.fromhex(self.persistent_cache["game_time_cache"])

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -81,8 +81,8 @@ class RiotPlugin(Plugin):
     async def uninstall_game(self, game_id):
         self.local_client.update_installed()
         self.local_client.uninstall(game_id)
-        if game_id == GameID.valorant and self.local_client._vangaurd_uninstall_path is not None:
-            utils.open_path(self.local_client._vangaurd_uninstall_path)
+        if game_id == GameID.valorant and self.local_client._vanguard_uninstall_path is not None:
+            utils.open_path(self.local_client._vanguard_uninstall_path)
 
     async def launch_game(self, game_id):
         self.local_client.update_installed()

--- a/src/utils.py
+++ b/src/utils.py
@@ -20,6 +20,13 @@ async def get_size_at_path(start_path, *, if_none=None):
     log.debug(f"Size: {total_size} bytes - {start_path}")
     return total_size  # in bytes
 
+def get_product_settings_path(game_id):
+    # Given the game ID, returns the path of the product settings yaml file.
+    return os.path.expandvars("%PROGRAMDATA%\\Riot Games\\Metadata\\{0}.live\\{0}.live.product_settings.yaml".format(game_id))
+
+def get_riot_client_installs_path():
+    # Returns the path of the Riot Client settings yaml file.
+    return os.path.expandvars("%PROGRAMDATA%\\Riot Games\\RiotClientInstalls.json")
 
 def run(cmd, *, shell=False):
     log.info(f"Running: {cmd}")


### PR DESCRIPTION
Replaced most registry-based detection with YAML and JSON-based detection for the games and RiotClientServices.
Created two new helper functions in utils/misc: get_product_settings_path(game_id) and get_riot_client_installs_path().
I'm not currently aware of how to detect Vanguard's location without using the registry and had to leave the code for that in place.

Merged into dev and fixed utils import to utils.misc as well as some miscellaneous typos.

Fixes issues #6 and possibly #10. 