### PR TITLE
get_local_games() to return actually installed games instead of all games

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ A GOG Galaxy 2.0 Community integration for Riot!
 
 ![games_example](https://raw.githubusercontent.com/urwrstkn8mare/gog-riot-integration/master/screenshot.png)
 
-_Note: If you're wondering why the icon is odd (missing) see this [issue](https://github.com/urwrstkn8mare/gog-riot-integration/issues/1#issuecomment-641019594)._
-
 ## Usage / Installation
 
 1. Download the latest release from [releases](https://github.com/urwrstkn8mare/galaxy-riot-integration/releases).
@@ -24,6 +22,10 @@ _Note: If you're wondering why the icon is odd (missing) see this [issue](https:
 ## [Known Issues](https://github.com/urwrstkn8mare/galaxy-riot-integration/labels/known%20issue)
 
 See [known issues](https://github.com/urwrstkn8mare/galaxy-riot-integration/labels/known%20issue) in [issues](https://github.com/urwrstkn8mare/galaxy-riot-integration/issues). They will have the [known issue](https://github.com/urwrstkn8mare/galaxy-riot-integration/labels/known%20issue) [label](https://github.com/urwrstkn8mare/galaxy-riot-integration/labels).
+
+Note: 
+- If you're wondering why the icon is odd (missing) see this [issue](https://github.com/urwrstkn8mare/gog-riot-integration/issues/1#issuecomment-641019594).
+- If you used the Rockstar plugin before or currently and are experiencing issues (like plugin not starting on client launch) see [this issue](https://github.com/urwrstkn8mare/galaxy-riot-integration/issues/13#issuecomment-757138499) for a solution. (courtesy of [@fl4shback](https://github.com/fl4shback))
 
 ## Issues
 

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -62,8 +62,13 @@ class RiotPlugin(Plugin):
 
     async def get_local_games(self):
         log.info("Getting local games")
-        out = [LocalGame(key, self.status[key]) for key in self.status.keys()]
-        return out
+        local_games = []
+        for game_id in GAME_IDS:
+            if self.local_client.game_installed(game_id):
+                local_game = LocalGame(game_id, LocalGameState.Installed)
+                local_games.append(local_game)
+        log.debug(f"RIOT_INSTALLED_GAMES: {local_games}")
+        return local_games
 
     async def prepare_local_size_context(self, game_ids):
         sizes = []


### PR DESCRIPTION
Small patch to only show installed games as installed instead of all games when grouping by installed status in galaxy.

Never thought I would use the word installed so many times in one sentence !

![image](https://user-images.githubusercontent.com/57314569/104359951-9c985a00-5510-11eb-9961-1f8e9414917f.png)

(previously, all games were under the "installé/installed" section)
